### PR TITLE
Joining LnasGeometry bug fix

### DIFF
--- a/lnas/geometry.py
+++ b/lnas/geometry.py
@@ -210,11 +210,13 @@ class LnasGeometry:
             geometries_list (list[LnasGeometry]): List of LnasGeometry to be combined
         """
         if len(geometries_list) < 1:
-            raise ValueError("No geometry to combine. It must be a list of at least two LnasGeometry")
+            raise ValueError(
+                "No geometry to combine. It must be a list of at least two LnasGeometry"
+            )
 
         for geometry in geometries_list:
             new_tri = geometry.triangles.copy() + len(self.vertices)
             self.vertices = np.vstack((self.vertices, geometry.vertices.copy()))
-            self.triangles = np.vstack((new_tri, geometry.triangles.copy()))
+            self.triangles = np.vstack((self.triangles, new_tri))
 
         self._full_update()

--- a/tests/testLnasGeometry.py
+++ b/tests/testLnasGeometry.py
@@ -16,7 +16,7 @@ class TestLnasGeometry(unittest.TestCase):
         geometry = geometry.copy()
         geometry.join([other_geometry])
 
-        expected_tri = np.array([[4, 5, 6], [5, 7, 6], [0, 1, 2], [1, 3, 2]])
+        expected_tri = np.array([[0, 1, 2], [1, 3, 2], [4, 5, 6], [5, 7, 6]])
 
         self.assertIsInstance(geometry, LnasGeometry)
         self.assertTrue((geometry.triangles == expected_tri).all())


### PR DESCRIPTION
A bug was found when joining multiple LnasGeometry.

The order of the resulted geometry triangles didn't match with the geometry list sequence.